### PR TITLE
Readme Updation pre-requisites and examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,28 +14,36 @@ Make sure you have Node.js and npm (Node Package Manager) installed on your syst
 
 You also need to install the Protocol Buffers Compiler (`protoc`). Instructions for installing `protoc` can be found in the [Protocol Buffers documentation](https://developers.google.com/protocol-buffers/docs/downloads).
 
-Once you have installed Node.js, npm, and `protoc`, you're ready to proceed.
+Once you have installed Node.js, npm, and `protoc`, you're ready to proceed. You can confirm the installations via these comamnds:
+
+```bash
+node -v
+```
+
+```bash
+npm -v
+```
+
+```bash
+protoc --version
+```
 
 ## Usage
 
 This repository provides npm scripts to simplify the process of generating code from the .proto files. Here's how you can use them:
 
-### 1. Generating code with npm script `generate:protos:amaterasu`
+### Pre-requisites
+
+- These commands can only be executed using a bash instance, which can be opened using GitBash or in VS Code.
+
+- Run `npm install` once at the project directory level before proceeding.
+
+### 1. Generating code for Amaterasu with npm script `generate:protos:amaterasu`
 
 This script downloads any necessary dependencies via npm before generating code. Make sure you have an active internet connection before running this script.
 
 ```bash
 npm run generate:protos:amaterasu /path/to/protos
-```
-
-Replace `/path/to/protos` with the path to the directory containing your .proto files.
-
-### 2. Generating code with npm script `generate:protos:rinnegan`
-
-This script assumes that you have already installed `protoc` on your system.
-
-```bash
-npm run generate:protos:rinnegan /path/to/protos
 ```
 
 Replace `/path/to/protos` with the path to the directory containing your .proto files.
@@ -50,7 +58,26 @@ npm run generate:protos:amaterasu testing-folder/dummy.proto
 
 This command will generate code from the .proto files located in the `protos` directory.
 
+### 2. Generating code for Rinnegan with npm script `generate:protos:rinnegan`
+
+This script assumes that you have already installed `protoc` on your system.
+
+```bash
+npm run generate:protos:rinnegan /path/to/protos
+```
+
+Replace `/path/to/protos` with the path to the directory containing your .proto files.
+
+## Example
+
+Here's an example of how you can use the npm scripts to generate code:
+
+```bash
+npm run generate:protos:rinnegan testing-folder/dummy.proto
+```
+
+This command will generate code from the .proto files located in the `protos` directory.
+
 ## License
 
 This repository is licensed under the [Kubair License].
-


### PR DESCRIPTION
1. Commands to run for confirm installation of NodeJS and protoc have been added.
2. A pre-requisite section in usage has been added to highlight bash instance requirement and installing node packages before proceeding with running any shell scripts.
3. Example for Amaterasu and Rinnegan have been properly added.