### PR TITLE
Protos for Terms & Conditions Screen

### DIFF
--- a/protos-frontend/UI/Button.proto
+++ b/protos-frontend/UI/Button.proto
@@ -9,11 +9,10 @@ option go_package = "Rinnegan/proto-generated/protos-frontend/UI";
 
 // Define a message structure for a Button.
 message Button {
-   // The text displayed on the button.
-    UI.Text text = 1;
+  // The text displayed on the button.
+  UI.Text text = 1;
   // The corner radius of the button.
   UI.CornerRadius corner_radius = 2;
-
-    // The background color of the button.
+  // The background color of the button.
   string background_color = 3;
 }

--- a/protos-frontend/UI/CheckBox.proto
+++ b/protos-frontend/UI/CheckBox.proto
@@ -1,9 +1,7 @@
 syntax = "proto3";
 
-// Import Text message from UI/Text.proto
 import "protos-frontend/UI/Text.proto";
 
-// Define the package name
 package UI;
 
 // Set the Go package name to "Rinnegan/proto-generated/protos-frontend/UI"

--- a/protos-frontend/UI/Secure.proto
+++ b/protos-frontend/UI/Secure.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+/**
+ * Import Image message from UI/Image.proto
+ * This import allows us to use the Image message in our Secure message
+ */
+import "protos-frontend/UI/Image.proto";
+
+/**
+ * Import Text message from UI/Text.proto
+ * This import allows us to use the Text message in our Secure message
+ */
+import "protos-frontend/UI/Text.proto";
+
+/**
+ * Define the package name
+ * This package contains messages related to UI components
+ */
+package UI;
+
+/**
+ * Set the Go package name to "Rinnegan/proto-generated/protos-frontend/UI"
+ * This option specifies the Go package name to use when generating code
+ */
+option go_package = "Rinnegan/proto-generated/protos-frontend/UI";
+
+/**
+ * Secure message
+ * Represents a secure UI component with a URL, image, and text.
+ */
+message Secure {
+  /**
+   * URL of the secure component
+   */
+  string url = 1;
+  
+  /**
+   * Image component of the secure component
+   */
+  UI.Image image = 2;
+  
+  /**
+   * Text component of the secure component
+   */
+  UI.Text text = 3;
+}

--- a/protos-frontend/UI/Secure.proto
+++ b/protos-frontend/UI/Secure.proto
@@ -1,27 +1,10 @@
 syntax = "proto3";
 
-/**
- * Import Image message from UI/Image.proto
- * This import allows us to use the Image message in our Secure message
- */
 import "protos-frontend/UI/Image.proto";
-
-/**
- * Import Text message from UI/Text.proto
- * This import allows us to use the Text message in our Secure message
- */
 import "protos-frontend/UI/Text.proto";
 
-/**
- * Define the package name
- * This package contains messages related to UI components
- */
 package UI;
 
-/**
- * Set the Go package name to "Rinnegan/proto-generated/protos-frontend/UI"
- * This option specifies the Go package name to use when generating code
- */
 option go_package = "Rinnegan/proto-generated/protos-frontend/UI";
 
 /**

--- a/protos-frontend/UI/Terms.proto
+++ b/protos-frontend/UI/Terms.proto
@@ -1,24 +1,10 @@
 syntax = "proto3";
 
-/**
- * Import Image message from UI/Image.proto
- * This import allows us to use the Image message in our Terms message
- */
 import "protos-frontend/UI/Image.proto";
-
-/**
- * Import Text message from UI/Text.proto
- * This import allows us to use the Text message in our Terms message
- */
 import "protos-frontend/UI/Text.proto";
 
-/**
- * Define the package name
- * This package contains messages related to UI components
- */
 package UI;
 
-// Set the Go package name to "Rinnegan/proto-generated/protos-frontend/UI"
 option go_package = "Rinnegan/proto-generated/protos-frontend/UI";
 
 /**

--- a/protos-frontend/UI/Terms.proto
+++ b/protos-frontend/UI/Terms.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+/**
+ * Import Image message from UI/Image.proto
+ * This import allows us to use the Image message in our Terms message
+ */
+import "protos-frontend/UI/Image.proto";
+
+/**
+ * Import Text message from UI/Text.proto
+ * This import allows us to use the Text message in our Terms message
+ */
+import "protos-frontend/UI/Text.proto";
+
+/**
+ * Define the package name
+ * This package contains messages related to UI components
+ */
+package UI;
+
+// Set the Go package name to "Rinnegan/proto-generated/protos-frontend/UI"
+option go_package = "Rinnegan/proto-generated/protos-frontend/UI";
+
+/**
+ * Terms message
+ * Represents a terms component with a URL, image, and text.
+ */
+message Terms {
+  /**
+   * URL of the terms component
+   */
+  string url = 1;
+  
+  /**
+   * Image component of the terms
+   */
+  Image image = 2;
+  
+  /**
+   * Text component of the terms
+   */
+  Text text = 3;
+}

--- a/protos-frontend/enums/PermissionTypes.proto
+++ b/protos-frontend/enums/PermissionTypes.proto
@@ -24,4 +24,20 @@ enum PermissionType {
    * This value represents permission for location access
    */
   LOCATION = 1;
+
+   /**
+   * Terms and conditions permission
+   */
+  TERMS_AND_CONDITIONS = 2;
+  
+  /**
+   * Data sharing permission
+   */
+  DATA_SHARING = 3;
+  
+  /**
+   * Other types of permissions
+   */
+  OTHER_PERMISSIONS = 4;
+
 }

--- a/protos-frontend/frontend/FrontendService.proto
+++ b/protos-frontend/frontend/FrontendService.proto
@@ -3,6 +3,16 @@ syntax = "proto3";
 import "protos-frontend/generic/GenericMessages.proto";
 import "protos-frontend/onboarding/rpc.proto";
 
+import "protos-frontend/enums/ResponseType.proto";
+import "protos-frontend/enums/PermissionTypes.proto";
+import "protos-frontend/UI/Button.proto";
+import "protos-frontend/UI/Image.proto";
+import "protos-frontend/UI/Text.proto";
+import "protos-frontend/UI/Terms.proto";
+import "protos-frontend/UI/Secure.proto";
+import "protos-frontend/UI/Modal.proto";
+import "protos-frontend/UI/CheckBox.proto";
+
 package frontend;
 
 option go_package = "Rinnegan/proto-generated/protos-frontend/frontend";
@@ -29,4 +39,95 @@ service FrontendService {
     rpc GetOtherConsentsScreen(generic.EmptyRequest) returns (onboarding.GetOtherConsentsScreenResponse){}
 
     rpc GetCurrentOnboardingStage(generic.EmptyRequest) returns (onboarding.GetCurrentOnboardingStageResponse){}
+
+    rpc GetTermsConditionsScreen(GetTermsConditionsScreenRequest) returns (GetTermsConditionsScreenResponse);
+}
+
+/**
+ * Request message for GetTermsConditionsScreen RPC
+ * Represents the request to get the Terms & Conditions screen.
+ */
+message GetTermsConditionsScreenRequest {
+
+  /**
+   * User ID of the user requesting the screen
+   */
+  string user_id = 1;
+
+  /**
+   * Whether the user has granted permission
+   */
+  bool is_permission_granted = 2;
+
+  /**
+   * List of permissions being requested
+   */
+  repeated enums.PermissionType requested_permissions = 3;
+
+ /**
+   * Device ID of the device making the request
+   */
+  string device_id = 4;
+
+  /**
+   * App version of the app making the request
+   */
+  string app_version = 5;
+}
+
+/**
+ * Response message for GetTermsConditionsScreen RPC
+ * Represents the response to the GetTermsConditionsScreen RPC method.
+ */
+message GetTermsConditionsScreenResponse {
+
+  /**
+   * Image to display on the permission screen
+   */
+  UI.Image top_image = 1;
+
+  /**
+   * Header text to display on the permission screen
+   */
+  UI.Text title = 2;
+
+  /**
+   * Paragraph text to display on the permission screen
+   */
+  UI.Text subtitle = 3;
+
+  /**
+   * Notifications consent component
+   */
+  UI.Terms terms = 4;
+
+  /**
+   * Location consent component
+   */
+  UI.Secure secure = 5;
+
+/**
+   * Next button component
+   */
+  UI.Button next_button = 6;
+
+  /**
+   * Agreement checkbox component
+   */
+  UI.CheckBox agreement_checkbox = 7;
+
+  /**
+   *Data sharing checkbox component
+   */
+  UI.CheckBox data_sharing_checkbox = 8;
+
+   /**
+   * Alert modal component
+   */
+  UI.Modal alert_modal = 9;
+
+   /**
+   * Error type (if any)
+   */
+   enums.ErrorType error = 10;
 }


### PR DESCRIPTION
Adds new proto files for the Terms & Conditions screen service, which provides a feature for users to view and agree to terms and conditions. The service includes a single RPC method, GetTermsConditionsScreen, which returns a response containing various UI components, including images, text, buttons, and checkboxes